### PR TITLE
Makefile now works for Blinky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TARGET = $(FILE)
 # MCU: part number to build for
 MCU = atmega16m1
 # SOURCES: list of input source sources
-SOURCES = $(FILE).c api.c uart.c
+SOURCES = $(FILE).c
 # INC: list of build dependencies
 INC = -Isrc/
 # OUTDIR: directory to use for output

--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Note that {name} should be the filename of the \*.c code you wish to flash witho
 ```
 $ sudo make FILE=blinky flash
 ```
+
+## TODO
+Make more nodes


### PR DESCRIPTION
The makefile used to include api.c and uart.c, that broke things. I fixed it. I also added a part to the README about TODOs
